### PR TITLE
feat : 쿠폰 유효 기간 출력 및 alert 설정

### DIFF
--- a/src/main/java/com/example/high_five/dto/coupon/CouponPolicyRequestDto.java
+++ b/src/main/java/com/example/high_five/dto/coupon/CouponPolicyRequestDto.java
@@ -19,6 +19,7 @@ public class CouponPolicyRequestDto {
     private Long discountValue;
     private Long minOrderValue;
     private Long maxDiscountValue;
+    private Integer validPeriodDate;
     private List<Long> targetCategoryIds = new ArrayList<>();
     private List<Long> targetBookIds = new ArrayList<>();
 }

--- a/src/main/java/com/example/high_five/dto/coupon/MemberCouponResponseDto.java
+++ b/src/main/java/com/example/high_five/dto/coupon/MemberCouponResponseDto.java
@@ -15,8 +15,12 @@ public class MemberCouponResponseDto {
     private Long id;
     private String couponName;
     private String status;
+    private LocalDateTime issuedAt;
+    private LocalDateTime usedAt;
+    private LocalDateTime expiredAt;
+    private Long orderId;
     private Long discountValue;
     private String discountType;
-    private LocalDateTime expiredAt;
     private String condition;
+    private Long daysRemained;
 }

--- a/src/main/resources/templates/mypage/coupons.html
+++ b/src/main/resources/templates/mypage/coupons.html
@@ -46,6 +46,18 @@
                 <div class="coupon-header">
                     <div class="coupon-title" th:text="${coupon.couponName}">쿠폰 이름</div>
                     <div style="display: flex; align-items: center; gap: 8px;">
+                         <th:block th:if="${coupon.status.toString() == 'ISSUED' && coupon.daysRemained != null}">
+                            <span class="coupon-badge" style="background-color: #ff4d4f; color: white;"
+                                  th:if="${coupon.daysRemained == 0}">
+                                오늘 만료
+                            </span>
+
+                            <span class="coupon-badge" style="background-color: #ff4d4f; color: white;"
+                                  th:if="${coupon.daysRemained > 0}"
+                                  th:text="|D-${coupon.daysRemained}|">
+                                    D-Day
+                            </span>
+                         </th:block>
                          <span class="coupon-badge"
                                th:classappend="${coupon.status == 'ISSUED'} ? 'badge-available' :
                                               (${coupon.status == 'USED'} ? 'badge-used' : 'badge-expired')"

--- a/src/main/resources/templates/order/coupon-register.html
+++ b/src/main/resources/templates/order/coupon-register.html
@@ -42,5 +42,21 @@
 
 </div>
 
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    document.addEventListener('DOMContentLoaded', function() {
+        var message = [[${message}]];
+        var errorMessage = [[${errorMessage}]];
+
+        if (message) {
+            alert(message);
+        }
+        if (errorMessage) {
+            alert(errorMessage);
+        }
+    });
+    /*]]>*/
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 쿠폰 유효 기간 출력 및 alert 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 쿠폰 정책에 유효 기간 설정 기능 추가
  * 마이페이지 쿠폰 목록에서 남은 기간(D-day) 또는 "오늘 만료" 배지 표시
  * 쿠폰 상세 정보에 발급일, 사용일, 만료일, 주문 ID 추가
  * 쿠폰 등록 시 완료/오류 알림 메시지 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->