### PR TITLE
✨ feat: 관리자 매출 통계 기능 뷰 구현

### DIFF
--- a/src/main/java/com/example/high_five/controller/admin/PaymentAdminController.java
+++ b/src/main/java/com/example/high_five/controller/admin/PaymentAdminController.java
@@ -1,0 +1,53 @@
+package com.example.high_five.controller.admin;
+
+import com.example.high_five.dto.payment.DailySalesResponse;
+import com.example.high_five.dto.payment.PaymentStatsResponse;
+import com.example.high_five.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/payments")
+@RequiredArgsConstructor
+public class PaymentAdminController {
+
+    private final PaymentService paymentClient;
+
+    @GetMapping("/stats")
+    public String paymentStatsPage(
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            Model model) {
+
+        // 1. 전체 요약 통계 조회
+        try {
+            PaymentStatsResponse summary = paymentClient.getTotalStats();
+            model.addAttribute("summary", summary);
+        } catch (Exception e) {
+            model.addAttribute("summary", new PaymentStatsResponse(0L, 0L, 0L, 0L, 0L, 0L));
+        }
+
+        // 2. 일별 매출 차트 데이터 조회 (기본값: 최근 7일)
+        if (endDate == null) endDate = LocalDate.now();
+        if (startDate == null) startDate = endDate.minusDays(6);
+
+        try {
+            List<DailySalesResponse> dailyStats = paymentClient.getDailyStats(startDate, endDate);
+            model.addAttribute("dailyStats", dailyStats);
+        } catch (Exception e) {
+            model.addAttribute("dailyStats", List.of());
+        }
+
+        model.addAttribute("startDate", startDate);
+        model.addAttribute("endDate", endDate);
+
+        return "admin/payment-stats";
+    }
+}

--- a/src/main/java/com/example/high_five/dto/payment/DailySalesResponse.java
+++ b/src/main/java/com/example/high_five/dto/payment/DailySalesResponse.java
@@ -1,0 +1,15 @@
+package com.example.high_five.dto.payment;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailySalesResponse {
+    private LocalDate date;
+    private Long dailyTotalAmount;
+    private Long dailyCount;
+}

--- a/src/main/java/com/example/high_five/dto/payment/PaymentStatsResponse.java
+++ b/src/main/java/com/example/high_five/dto/payment/PaymentStatsResponse.java
@@ -1,0 +1,17 @@
+package com.example.high_five.dto.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentStatsResponse {
+    private Long totalSalesAmount;      // 총 매출
+    private Long totalCancelAmount;     // 환불 금액
+    private Long netSalesAmount;        // 순 매출
+    private Long totalTransactionCount; // 총 결제 건수
+    private Long successCount;          // 성공 건수
+    private Long cancelCount;           // 취소 건수
+}

--- a/src/main/java/com/example/high_five/service/PaymentService.java
+++ b/src/main/java/com/example/high_five/service/PaymentService.java
@@ -1,0 +1,24 @@
+package com.example.high_five.service;
+
+import com.example.high_five.dto.payment.DailySalesResponse;
+import com.example.high_five.dto.payment.PaymentStatsResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@FeignClient(name = "payment-server", url = "${gateway.uri}")
+public interface PaymentService {
+
+    @GetMapping("/api/payments/admin/stats/summary")
+    PaymentStatsResponse getTotalStats();
+
+    @GetMapping("/api/payments/admin/stats/daily")
+    List<DailySalesResponse> getDailyStats(
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    );
+}

--- a/src/main/resources/static/admin-css/payment-stats.css
+++ b/src/main/resources/static/admin-css/payment-stats.css
@@ -1,0 +1,176 @@
+/* 공통 변수 (기존 스타일 상속) */
+:root {
+    --color-primary: #007bff;
+    --color-accent: #e9c46a;
+    --color-bg: #f6f8fb;
+    --color-dark: #333;
+    --color-light: #fff;
+    --color-border: #ddd;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans KR", sans-serif;
+    background-color: var(--color-bg);
+    color: var(--color-dark);
+    display: flex;
+    min-height: 100vh;
+}
+
+/* 사이드바 스타일 */
+.sidebar {
+    width: 220px;
+    background-color: #1e1e2f;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    padding-top: 30px;
+    position: fixed;
+    height: 100%;
+}
+.sidebar h2 { text-align: center; font-size: 20px; margin-bottom: 40px; color: var(--color-accent); }
+.menu { list-style: none; }
+.menu li { margin-bottom: 10px; }
+.menu a { display: block; padding: 12px 20px; color: #ccc; text-decoration: none; font-weight: 500; }
+.menu a:hover, .menu a.active { background-color: #2f2f45; color: var(--color-accent); }
+
+/* 콘텐츠 영역 */
+.content-area {
+    margin-left: 220px;
+    flex: 1;
+    background: var(--color-bg);
+}
+
+header {
+    background-color: var(--color-primary);
+    color: #fff;
+    padding: 16px 40px;
+    font-weight: 700;
+    font-size: 18px;
+    margin-bottom: 20px;
+}
+
+main { padding: 0 40px 40px; }
+
+/* 1. 요약 카드 그리드 */
+.stats-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.stat-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    border-left: 5px solid #ccc;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+/* 카드 색상별 포인트 */
+.stat-card.blue { border-left-color: #007bff; }
+.stat-card.green { border-left-color: #28a745; }
+.stat-card.red { border-left-color: #dc3545; }
+.stat-card.yellow { border-left-color: #e9c46a; }
+
+.stat-card h3 {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.stat-card .stat-value {
+    font-size: 28px;
+    font-weight: 800;
+    color: #333;
+    margin-bottom: 5px;
+}
+
+.stat-card .stat-desc {
+    font-size: 12px;
+    color: #999;
+}
+
+/* 2. 차트 영역 */
+
+/* 날짜 검색바 영역 */
+.chart-header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    padding: 0 10px;
+}
+
+.date-filter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.date-filter input[type="date"] {
+    padding: 6px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+}
+
+.date-filter button {
+    padding: 6px 14px;
+    background-color: var(--color-dark);
+    color: #fff;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+/* 차트 2개를 감싸는 그리드 (1열 배치 - 위아래) */
+.charts-grid {
+    display: grid;
+    grid-template-columns: 1fr; /* 한 줄에 1개씩 (위아래 배치) */
+    gap: 40px;                  /* 차트 간 간격 */
+    margin-bottom: 40px;
+}
+
+/* 개별 차트 박스 */
+.chart-box {
+    background: #fff;
+    border-radius: 12px;
+    padding: 25px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    min-height: 400px; /* 높이 넉넉하게 확보 */
+}
+
+.chart-box h4 {
+    margin-bottom: 15px;
+    font-size: 16px;
+    color: #444;
+    font-weight: 700;
+    border-left: 4px solid var(--color-primary);
+    padding-left: 10px;
+}
+
+/* 차트 캔버스 (높이 350px로 통일) */
+.canvas-wrapper {
+    position: relative;
+    height: 350px;
+    width: 100%;
+}
+
+/* 반응형 (모바일) */
+@media (max-width: 1200px) {
+    .stats-summary-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .sidebar { display: none; }
+    .content-area { margin-left: 0; }
+    .stats-summary-grid { grid-template-columns: 1fr; }
+}

--- a/src/main/resources/templates/admin/book-coupons.html
+++ b/src/main/resources/templates/admin/book-coupons.html
@@ -60,6 +60,7 @@
         <li><a href="/admin/points/policy">포인트 관리</a></li>
         <li><a href="/admin/coupons/page">쿠폰 관리</a></li>
         <li><a href="/admin/coupons/specific-book-coupons" class="active">특정 도서 쿠폰 관리</a></li>
+        <li><a href="/admin/payments/stats">매출 통계</a></li>
     </ul>
 </aside>
 

--- a/src/main/resources/templates/admin/books.html
+++ b/src/main/resources/templates/admin/books.html
@@ -16,6 +16,7 @@
         <li><a href="/admin/points" data-key="points">포인트 정책 관리</a></li>
         <li><a href="/admin/coupons" data-key="coupons">쿠폰 관리</a></li>
         <li><a href="/admin/coupons/specific-book-coupons">특정 도서 쿠폰 관리</a></li>
+        <li><a href="/admin/payments/stats">매출 통계</a></li>
     </ul>
 </aside>
 

--- a/src/main/resources/templates/admin/coupons.html
+++ b/src/main/resources/templates/admin/coupons.html
@@ -15,6 +15,7 @@
         <li><a href="/admin/points">포인트 관리</a></li>
         <li><a href="/admin/coupons/page" class="active">쿠폰 관리</a></li>
         <li><a href="/admin/coupons/specific-book-coupons">특정 도서 쿠폰 관리</a></li>
+        <li><a href="/admin/payments/stats">매출 통계</a></li>
     </ul>
 </aside>
 

--- a/src/main/resources/templates/admin/payment-stats.html
+++ b/src/main/resources/templates/admin/payment-stats.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Highfive 관리자 - 결제/매출 통계</title>
+    <link rel="stylesheet" href="/admin-css/payment-stats.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+
+<aside class="sidebar">
+    <h2>HIGHFIVE 관리자</h2>
+    <ul class="menu">
+        <li><a href="/admin/books">도서 관리</a></li>
+        <li><a href="/admin/points/policy">포인트 관리</a></li>
+        <li><a href="/admin/coupons/page">쿠폰 관리</a></li>
+        <li><a href="/admin/coupons/specific-book-coupons">특정 도서 쿠폰 관리</a></li>
+        <li><a href="/admin/payments/stats" class="active">매출 통계</a></li>
+    </ul>
+</aside>
+
+<div class="content-area">
+    <header>
+        <h1>결제 및 매출 통계</h1>
+    </header>
+
+    <main>
+        <div class="stats-summary-grid">
+            <div class="stat-card blue">
+                <h3>총 매출액</h3>
+                <p class="stat-value" th:text="${#numbers.formatInteger(summary.totalSalesAmount, 0, 'COMMA')} + '원'">0원</p>
+                <p class="stat-desc">누적 결제 금액</p>
+            </div>
+            <div class="stat-card green">
+                <h3>순 매출액</h3>
+                <p class="stat-value" th:text="${#numbers.formatInteger(summary.netSalesAmount, 0, 'COMMA')} + '원'">0원</p>
+                <p class="stat-desc">총 매출 - 환불 금액</p>
+            </div>
+            <div class="stat-card red">
+                <h3>환불 금액</h3>
+                <p class="stat-value" th:text="${#numbers.formatInteger(summary.totalCancelAmount, 0, 'COMMA')} + '원'">0원</p>
+                <div class="stat-sub">
+                    <span>취소 건수: </span><strong th:text="${summary.cancelCount}">0</strong>건
+                </div>
+            </div>
+            <div class="stat-card yellow">
+                <h3>결제 성공률</h3>
+                <p class="stat-value">
+                    <span th:if="${summary.totalTransactionCount > 0}"
+                          th:text="${#numbers.formatDecimal((summary.successCount * 100.0) / summary.totalTransactionCount, 1, 1)} + '%'">0.0%</span>
+                    <span th:unless="${summary.totalTransactionCount > 0}">0%</span>
+                </p>
+                <p class="stat-desc">총 <span th:text="${summary.totalTransactionCount}">0</span>건 중 성공</p>
+            </div>
+        </div>
+
+        <div class="chart-header-row">
+            <h3>기간별 통계 상세</h3>
+            <form method="get" action="/admin/payments/stats" class="date-filter">
+                <input type="date" name="startDate" th:value="${startDate}">
+                <span>~</span>
+                <input type="date" name="endDate" th:value="${endDate}">
+                <button type="submit">조회</button>
+            </form>
+        </div>
+
+        <div class="charts-grid">
+            <div class="chart-box card">
+                <h4>일별 매출액 추이</h4>
+                <div class="canvas-wrapper">
+                    <canvas id="amountChart"></canvas>
+                </div>
+            </div>
+
+            <div class="chart-box card">
+                <h4>일별 결제 건수</h4>
+                <div class="canvas-wrapper">
+                    <canvas id="countChart"></canvas>
+                </div>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    const dailyData = [[${dailyStats}]];
+
+    const labels = dailyData.map(d => d.date);
+    const dataAmount = dailyData.map(d => d.dailyTotalAmount);
+    const dataCount = dailyData.map(d => d.dailyCount);
+
+    // 1. 매출액 차트 (Line Chart) - 파란색
+    const ctxAmount = document.getElementById('amountChart').getContext('2d');
+    new Chart(ctxAmount, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: '매출액 (원)',
+                data: dataAmount,
+                borderColor: '#007bff',
+                backgroundColor: 'rgba(0, 123, 255, 0.1)',
+                borderWidth: 2,
+                tension: 0.3, // 부드러운 곡선
+                fill: true,
+                pointRadius: 4,
+                pointHoverRadius: 6
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label: function(context) {
+                            return context.parsed.y.toLocaleString() + '원';
+                        }
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return value.toLocaleString(); // Y축 콤마 표시
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // 2. 결제 건수 차트 (Bar Chart) - 노란색/주황색
+    const ctxCount = document.getElementById('countChart').getContext('2d');
+    new Chart(ctxCount, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: '결제 건수 (건)',
+                data: dataCount,
+                backgroundColor: 'rgba(233, 196, 106, 0.8)', // 막대 색
+                borderColor: '#e9c46a',
+                borderWidth: 1,
+                borderRadius: 4 // 막대 둥글게
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 1 // 건수는 소수점이 안 나오게 1단위
+                    }
+                }
+            }
+        }
+    });
+    /*]]>*/
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/points.html
+++ b/src/main/resources/templates/admin/points.html
@@ -33,9 +33,10 @@
     <h2>HIGHFIVE 관리자</h2>
     <ul class="menu">
         <li><a href="/admin/books" data-key="members">도서 관리</a></li>
-        <li><a href="/admin/points/policy"  data-key="points">포인트 관리</a></li>
+        <li><a href="/admin/points/policy"  data-key="points" class="active">포인트 관리</a></li>
         <li><a href="/admin/coupons/page" data-key="coupons">쿠폰 관리</a></li>
         <li><a href="/admin/coupons/specific-book-coupons">특정 도서 쿠폰 관리</a></li>
+        <li><a href="/admin/payments/stats">매출 통계</a></li>
     </ul>
 </aside>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146

## 📝작업 내용

> 관리자가 매출 통계를 볼 수 있습니다!!!!!!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드에 매출 통계 페이지 추가: 총 매출액, 순 매출액, 환불 금액, 결제 성공률 요약 카드 표시
  * 날짜 범위 필터를 통한 일일 매출 데이터 조회 기능
  * 일일 매출액 및 결제 건수를 시각화하는 차트 제공

* **UI 개선**
  * 모든 관리자 페이지 사이드바 네비게이션에 "매출 통계" 메뉴 항목 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->