### PR TITLE
✨ feat: 마이페이지 주문 내역 구현

### DIFF
--- a/src/main/java/com/example/high_five/controller/order/MyOrderController.java
+++ b/src/main/java/com/example/high_five/controller/order/MyOrderController.java
@@ -1,6 +1,8 @@
 package com.example.high_five.controller.order;
 
 import com.example.high_five.common.CustomPage;
+import com.example.high_five.common.annotation.LoginRequired;
+import com.example.high_five.dto.member.response.MemberResponse;
 import com.example.high_five.dto.order.MyOrderResponse;
 import com.example.high_five.service.FrontOrderService;
 import com.example.high_five.service.MemberService;
@@ -9,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
@@ -19,27 +22,36 @@ public class MyOrderController {
     private final FrontOrderService frontOrderService;
     private final MemberService memberService;
 
-    @GetMapping("/mypage/orders")
-    public String myOrders(Model model,
-                           @RequestParam(defaultValue = "0") int page,
-                           @RequestParam(defaultValue = "10") int size) {
+    @ModelAttribute("myInfo")
+    public MemberResponse getMemberInfo() {
         try {
-            // 내 정보 조회 (UserID 획득용)
-            var myInfo = memberService.getMyInfo().getBody();
-            model.addAttribute("myInfo", myInfo);
-
-            if (myInfo != null) {
-                // 주문 내역 조회
-                CustomPage<MyOrderResponse> orderPage = frontOrderService.getMyOrders(myInfo.getMemberId(), page, size);
-                model.addAttribute("orders", orderPage.getContent());
-                model.addAttribute("page", orderPage);
+            var response = memberService.getMyInfo();
+            if (response != null && response.getBody() != null) {
+                return response.getBody();
             }
         } catch (Exception e) {
-            log.error("마이페이지 주문 내역 로드 실패", e);
+            log.warn("회원 정보 로드 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    @LoginRequired
+    @GetMapping("/mypage/orders")
+    public String myOrders(@ModelAttribute("myInfo") MemberResponse myInfo,
+                           Model model,
+                           @RequestParam(defaultValue = "0") int page,
+                           @RequestParam(defaultValue = "10") int size) {
+
+        if (myInfo == null) {
             return "redirect:/member/login.html";
         }
 
+        CustomPage<MyOrderResponse> orderPage = frontOrderService.getMyOrders(myInfo.getMemberId(), page, size);
+
+        model.addAttribute("orders", orderPage.getContent());
+        model.addAttribute("page", orderPage);
         model.addAttribute("currentTab", "orders");
+
         return "mypage/orders";
     }
 }

--- a/src/main/java/com/example/high_five/controller/order/MyOrderController.java
+++ b/src/main/java/com/example/high_five/controller/order/MyOrderController.java
@@ -1,0 +1,45 @@
+package com.example.high_five.controller.order;
+
+import com.example.high_five.common.CustomPage;
+import com.example.high_five.dto.order.MyOrderResponse;
+import com.example.high_five.service.FrontOrderService;
+import com.example.high_five.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class MyOrderController {
+
+    private final FrontOrderService frontOrderService;
+    private final MemberService memberService;
+
+    @GetMapping("/mypage/orders")
+    public String myOrders(Model model,
+                           @RequestParam(defaultValue = "0") int page,
+                           @RequestParam(defaultValue = "10") int size) {
+        try {
+            // 내 정보 조회 (UserID 획득용)
+            var myInfo = memberService.getMyInfo().getBody();
+            model.addAttribute("myInfo", myInfo);
+
+            if (myInfo != null) {
+                // 주문 내역 조회
+                CustomPage<MyOrderResponse> orderPage = frontOrderService.getMyOrders(myInfo.getMemberId(), page, size);
+                model.addAttribute("orders", orderPage.getContent());
+                model.addAttribute("page", orderPage);
+            }
+        } catch (Exception e) {
+            log.error("마이페이지 주문 내역 로드 실패", e);
+            return "redirect:/member/login.html";
+        }
+
+        model.addAttribute("currentTab", "orders");
+        return "mypage/orders";
+    }
+}

--- a/src/main/java/com/example/high_five/controller/point/PointController.java
+++ b/src/main/java/com/example/high_five/controller/point/PointController.java
@@ -1,6 +1,7 @@
 package com.example.high_five.controller.point;
 
 import com.example.high_five.common.CustomPage;
+import com.example.high_five.common.annotation.LoginRequired;
 import com.example.high_five.dto.point.PointBalanceResponse;
 import com.example.high_five.dto.point.PointHistoryResponse;
 import com.example.high_five.service.MemberService;
@@ -16,17 +17,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/mypage/points")
 public class PointController {
 
     private final MemberService memberService;
 
-    @GetMapping
+    @LoginRequired
+    @GetMapping("/mypage/points")
     public String pointPage(Model model,
                             @RequestParam(defaultValue = "0") int page,
                             @CookieValue(value = "access-token", required = false) String accessToken) {
 
-        if (accessToken == null) return "redirect:/member/login.html";
         String authHeader = "Bearer " + accessToken;
 
         try {

--- a/src/main/java/com/example/high_five/dto/member/response/MemberResponse.java
+++ b/src/main/java/com/example/high_five/dto/member/response/MemberResponse.java
@@ -9,6 +9,8 @@ import java.time.LocalDate;
 @Getter
 @Setter
 public class MemberResponse {
+    private Long memberId;
+
     private String name;
 
     private String email;

--- a/src/main/java/com/example/high_five/dto/order/MyOrderResponse.java
+++ b/src/main/java/com/example/high_five/dto/order/MyOrderResponse.java
@@ -1,0 +1,28 @@
+package com.example.high_five.dto.order;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyOrderResponse {
+
+    private Long orderId;
+    private LocalDateTime orderDate;
+    private String status;
+    private Integer totalAmount;
+    private List<MyOrderItemResponse> items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyOrderItemResponse {
+        private String bookTitle;
+        private Integer quantity;
+        private Integer price;
+    }
+}

--- a/src/main/java/com/example/high_five/service/FrontOrderService.java
+++ b/src/main/java/com/example/high_five/service/FrontOrderService.java
@@ -1,9 +1,11 @@
 package com.example.high_five.service;
 
+import com.example.high_five.common.CustomPage;
 import com.example.high_five.dto.book.response.BookResponse;
 import com.example.high_five.dto.coupon.MemberCouponResponseDto;
 import com.example.high_five.dto.member.response.MemberResponse;
 import com.example.high_five.dto.order.DeliveryPolicyResponse;
+import com.example.high_five.dto.order.MyOrderResponse;
 import com.example.high_five.dto.order.OrderCheckoutRequest;
 import com.example.high_five.dto.order.OrderResponse;
 import com.example.high_five.dto.point.PointBalanceResponse;
@@ -201,6 +203,16 @@ public class FrontOrderService {
         } catch (Exception e) {
             log.error("Order Cancel Failed: OrderID={}", orderId, e);
             throw new RuntimeException("주문 취소 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 내 주문 내역 조회
+    public CustomPage<MyOrderResponse> getMyOrders(Long userId, int page, int size) {
+        try {
+            return orderClient.getMyOrders(userId, page, size);
+        } catch (Exception e) {
+            log.error("주문 내역 조회 실패 UserID={}: {}", userId, e.getMessage());
+            return new CustomPage<>(Collections.emptyList(), 0, 0, size, page);
         }
     }
 

--- a/src/main/java/com/example/high_five/service/OrderClient.java
+++ b/src/main/java/com/example/high_five/service/OrderClient.java
@@ -1,6 +1,8 @@
 package com.example.high_five.service;
 
+import com.example.high_five.common.CustomPage;
 import com.example.high_five.dto.order.DeliveryPolicyResponse;
+import com.example.high_five.dto.order.MyOrderResponse;
 import com.example.high_five.dto.order.OrderCheckoutRequest;
 import com.example.high_five.dto.order.OrderResponse;
 import lombok.Getter;
@@ -40,4 +42,9 @@ public interface OrderClient {
 
     @PostMapping("/api/orders/{orderId}/cancel")
     void cancelOrder(@PathVariable("orderId") Long orderId);
+
+    @GetMapping("/api/orders")
+    CustomPage<MyOrderResponse> getMyOrders(@RequestHeader("X-USER-ID") Long userId,
+                                            @RequestParam("page") int page,
+                                            @RequestParam("size") int size);
 }

--- a/src/main/resources/templates/mypage/coupons.html
+++ b/src/main/resources/templates/mypage/coupons.html
@@ -13,16 +13,33 @@
     </style>
 </head>
 <body>
-<header id="header" role="banner">
+<header id="header">
     <div class="container">
         <a href="/" class="logo">
-            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100" />
+            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
             <div class="brand">HIGH-FIVE BOOKS</div>
         </a>
+        <nav class="gnb" aria-label="주요 메뉴">
+            <form class="search-box"
+                  role="search"
+                  th:action="@{/search}"
+                  method="get">
+                <input
+                        type="search"
+                        name="keyword"
+                        placeholder="도서명, 저자, ISBN, 태그 검색"
+                        aria-label="통합 검색"
+                />
+                <button type="submit" class="search-btn" aria-label="검색">검색</button>
+            </form>
+        </nav>
         <div class="user-menu">
             <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
             <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>
-            <a class="user-link" href="/api/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+            <a class="user-link" href="/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+
+            <a th:if="${myInfo == null}" class="user-link pill" th:href="@{/login}">로그인</a>
+            <a th:if="${myInfo != null}" class="user-link pill" th:href="@{/logout}">로그아웃</a>
         </div>
     </div>
 </header>

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -20,7 +20,20 @@
             <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
             <div class="brand">HIGH-FIVE BOOKS</div>
         </a>
-
+        <nav class="gnb" aria-label="주요 메뉴">
+            <form class="search-box"
+                  role="search"
+                  th:action="@{/search}"
+                  method="get">
+                <input
+                        type="search"
+                        name="keyword"
+                        placeholder="도서명, 저자, ISBN, 태그 검색"
+                        aria-label="통합 검색"
+                />
+                <button type="submit" class="search-btn" aria-label="검색">검색</button>
+            </form>
+        </nav>
         <div class="user-menu">
             <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
             <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>

--- a/src/main/resources/templates/mypage/orders.html
+++ b/src/main/resources/templates/mypage/orders.html
@@ -6,7 +6,6 @@
     <title>Booktown - 주문 내역</title>
     <link rel="stylesheet" href="/member-css/mypage.css">
     <style>
-        /* 주문 목록 스타일 간단 추가 */
         .order-card {
             border: 1px solid #ddd;
             border-radius: 8px;
@@ -61,11 +60,27 @@
             <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
             <div class="brand">HIGH-FIVE BOOKS</div>
         </a>
+        <nav class="gnb" aria-label="주요 메뉴">
+            <form class="search-box"
+                  role="search"
+                  th:action="@{/search}"
+                  method="get">
+                <input
+                        type="search"
+                        name="keyword"
+                        placeholder="도서명, 저자, ISBN, 태그 검색"
+                        aria-label="통합 검색"
+                />
+                <button type="submit" class="search-btn" aria-label="검색">검색</button>
+            </form>
+        </nav>
         <div class="user-menu">
             <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
             <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>
             <a class="user-link" href="/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
-            <a class="user-link pill" th:href="@{/logout}">로그아웃</a>
+
+            <a th:if="${myInfo == null}" class="user-link pill" th:href="@{/login}">로그인</a>
+            <a th:if="${myInfo != null}" class="user-link pill" th:href="@{/logout}">로그아웃</a>
         </div>
     </div>
 </header>

--- a/src/main/resources/templates/mypage/orders.html
+++ b/src/main/resources/templates/mypage/orders.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Booktown - 주문 내역</title>
+    <link rel="stylesheet" href="/member-css/mypage.css">
+    <style>
+        /* 주문 목록 스타일 간단 추가 */
+        .order-card {
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            background-color: #fff;
+        }
+        .order-header {
+            display: flex;
+            justify-content: space-between;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 10px;
+            margin-bottom: 10px;
+            font-weight: bold;
+            color: #555;
+        }
+        .order-item {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 5px;
+            font-size: 14px;
+        }
+        .order-footer {
+            margin-top: 15px;
+            text-align: right;
+            font-weight: bold;
+            font-size: 16px;
+        }
+        .status-badge {
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            background-color: #e9ecef;
+            color: #495057;
+        }
+        .status-WAITING { background-color: #fff3cd; color: #856404; }
+        .status-COMPLETED { background-color: #d4edda; color: #155724; }
+        .status-CANCELED { background-color: #f8d7da; color: #721c24; }
+
+        .no-data {
+            text-align: center;
+            padding: 50px;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+
+<header id="header">
+    <div class="container">
+        <a href="/" class="logo">
+            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
+            <div class="brand">HIGH-FIVE BOOKS</div>
+        </a>
+        <div class="user-menu">
+            <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
+            <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>
+            <a class="user-link" href="/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+            <a class="user-link pill" th:href="@{/logout}">로그아웃</a>
+        </div>
+    </div>
+</header>
+
+<div class="container2">
+    <nav class="box">
+        <a href="/mypage" class="tab-btn">내 정보</a>
+        <a href="/mypage/address" class="tab-btn">배송지</a>
+        <a href="/mypage/coupons" class="tab-btn">쿠폰</a>
+        <a href="/mypage/points" class="tab-btn">포인트</a>
+        <a href="/mypage/orders" class="tab-btn active">주문내역</a>
+        <a href="/mypage/reviews" class="tab-btn">리뷰</a>
+        <a href="/mypage/likes" class="tab-btn">찜 목록</a>
+    </nav>
+
+    <section class="tab-content active">
+        <h2 class="section-title">주문 내역</h2>
+
+        <div th:if="${orders == null || orders.isEmpty()}" class="no-data">
+            주문 내역이 없습니다.
+        </div>
+
+        <div th:each="order : ${orders}" class="order-card">
+            <div class="order-header">
+                <div>
+                    <span th:text="${#temporals.format(order.orderDate, 'yyyy-MM-dd HH:mm')}">2024-01-01</span>
+                    <span style="margin-left: 10px; font-size: 12px; color: #888;" th:text="'(주문번호: ' + ${order.orderId} + ')'"></span>
+                </div>
+                <div>
+                    <span class="status-badge"
+                          th:classappend="'status-' + ${order.status}"
+                          th:text="${order.status}">WAITING</span>
+                </div>
+            </div>
+
+            <div class="order-body">
+                <div th:each="item : ${order.items}" class="order-item">
+                    <span th:text="${item.bookTitle}">책 제목</span>
+                    <span>
+                        <span th:text="${item.quantity} + '권'">1권</span> /
+                        <span th:text="${#numbers.formatInteger(item.price, 0, 'COMMA')} + '원'">10,000원</span>
+                    </span>
+                </div>
+            </div>
+
+            <div class="order-footer">
+                총 결제금액: <span th:text="${#numbers.formatInteger(order.totalAmount, 0, 'COMMA')}">30,000</span>원
+
+                <div style="margin-top: 10px;">
+                    <button th:if="${order.status == 'WAITING'}"
+                            th:onclick="'cancelOrder(' + ${order.orderId} + ')'"
+                            style="padding: 5px 10px; font-size: 12px; cursor: pointer;">주문 취소</button>
+                </div>
+            </div>
+        </div>
+
+    </section>
+</div>
+
+<script>
+    function cancelOrder(orderId) {
+        if (!confirm('정말 주문을 취소하시겠습니까?')) return;
+
+        fetch(`/orders/api/${orderId}/cancel`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+            .then(response => {
+                if (response.ok) {
+                    alert('주문이 취소되었습니다.');
+                    window.location.reload();
+                } else {
+                    alert('주문 취소에 실패했습니다.');
+                }
+            })
+            .catch(error => console.error('Error:', error));
+    }
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/mypage/orders.html
+++ b/src/main/resources/templates/mypage/orders.html
@@ -13,6 +13,7 @@
             margin-bottom: 20px;
             background-color: #fff;
         }
+
         .order-header {
             display: flex;
             justify-content: space-between;
@@ -22,18 +23,21 @@
             font-weight: bold;
             color: #555;
         }
+
         .order-item {
             display: flex;
             justify-content: space-between;
             margin-bottom: 5px;
             font-size: 14px;
         }
+
         .order-footer {
             margin-top: 15px;
             text-align: right;
             font-weight: bold;
             font-size: 16px;
         }
+
         .status-badge {
             padding: 4px 8px;
             border-radius: 4px;
@@ -41,9 +45,21 @@
             background-color: #e9ecef;
             color: #495057;
         }
-        .status-WAITING { background-color: #fff3cd; color: #856404; }
-        .status-COMPLETED { background-color: #d4edda; color: #155724; }
-        .status-CANCELED { background-color: #f8d7da; color: #721c24; }
+
+        .status-WAITING {
+            background-color: #fff3cd;
+            color: #856404;
+        }
+
+        .status-COMPLETED {
+            background-color: #d4edda;
+            color: #155724;
+        }
+
+        .status-CANCELED {
+            background-color: #f8d7da;
+            color: #721c24;
+        }
 
         .no-data {
             text-align: center;
@@ -107,7 +123,8 @@
             <div class="order-header">
                 <div>
                     <span th:text="${#temporals.format(order.orderDate, 'yyyy-MM-dd HH:mm')}">2024-01-01</span>
-                    <span style="margin-left: 10px; font-size: 12px; color: #888;" th:text="'(주문번호: ' + ${order.orderId} + ')'"></span>
+                    <span style="margin-left: 10px; font-size: 12px; color: #888;"
+                          th:text="'(주문번호: ' + ${order.orderId} + ')'"></span>
                 </div>
                 <div>
                     <span class="status-badge"
@@ -132,9 +149,27 @@
                 <div style="margin-top: 10px;">
                     <button th:if="${order.status == 'WAITING'}"
                             th:onclick="'cancelOrder(' + ${order.orderId} + ')'"
-                            style="padding: 5px 10px; font-size: 12px; cursor: pointer;">주문 취소</button>
+                            style="padding: 5px 10px; font-size: 12px; cursor: pointer;">주문 취소
+                    </button>
                 </div>
             </div>
+        </div>
+
+        <div class="pagination" th:if="${page.totalPages > 1}">
+            <a th:if="${page.currentPage > 0}"
+               th:href="@{/mypage/orders(page=${page.currentPage - 1})}"
+               class="page-link">&lt;</a>
+
+            <span th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}">
+        <a th:href="@{/mypage/orders(page=${i})}"
+           th:text="${i + 1}"
+           th:classappend="${i == page.currentPage} ? 'active' : ''"
+           class="page-link">1</a>
+    </span>
+
+            <a th:if="${page.currentPage < page.totalPages - 1}"
+               th:href="@{/mypage/orders(page=${page.currentPage + 1})}"
+               class="page-link">&gt;</a>
         </div>
 
     </section>

--- a/src/main/resources/templates/mypage/points.html
+++ b/src/main/resources/templates/mypage/points.html
@@ -13,24 +13,33 @@
     </style>
 </head>
 <body>
-<header id="header" role="banner">
+<header id="header">
     <div class="container">
         <a href="/" class="logo">
-            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100" />
+            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
             <div class="brand">HIGH-FIVE BOOKS</div>
         </a>
         <nav class="gnb" aria-label="주요 메뉴">
-            <div class="search-box" role="search">
-                <input type="search" placeholder="검색어를 입력하세요" aria-label="통합 검색" />
-                <form method="get" action="/search">
-                    <button class="search-btn" type="submit">검색</button>
-                </form>
-            </div>
+            <form class="search-box"
+                  role="search"
+                  th:action="@{/search}"
+                  method="get">
+                <input
+                        type="search"
+                        name="keyword"
+                        placeholder="도서명, 저자, ISBN, 태그 검색"
+                        aria-label="통합 검색"
+                />
+                <button type="submit" class="search-btn" aria-label="검색">검색</button>
+            </form>
         </nav>
         <div class="user-menu">
             <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
             <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>
-            <a class="user-link" href="/api/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+            <a class="user-link" href="/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+
+            <a th:if="${myInfo == null}" class="user-link pill" th:href="@{/login}">로그인</a>
+            <a th:if="${myInfo != null}" class="user-link pill" th:href="@{/logout}">로그아웃</a>
         </div>
     </div>
 </header>

--- a/src/main/resources/templates/mypage/reviews.html
+++ b/src/main/resources/templates/mypage/reviews.html
@@ -61,24 +61,33 @@
     </style>
 </head>
 <body>
-<header id="header" role="banner">
+<header id="header">
     <div class="container">
         <a href="/" class="logo">
-            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100" />
+            <img src="/img/logo.png" alt="HIGH-FIVE 로고" width="100" height="100"/>
             <div class="brand">HIGH-FIVE BOOKS</div>
         </a>
         <nav class="gnb" aria-label="주요 메뉴">
-            <div class="search-box" role="search">
-                <input type="search" placeholder="검색어를 입력하세요" aria-label="통합 검색" />
-                <form method="get" action="/search">
-                    <button class="search-btn" type="submit">검색</button>
-                </form>
-            </div>
+            <form class="search-box"
+                  role="search"
+                  th:action="@{/search}"
+                  method="get">
+                <input
+                        type="search"
+                        name="keyword"
+                        placeholder="도서명, 저자, ISBN, 태그 검색"
+                        aria-label="통합 검색"
+                />
+                <button type="submit" class="search-btn" aria-label="검색">검색</button>
+            </form>
         </nav>
         <div class="user-menu">
             <a class="user-link" href="/coupon"><img src="/img/icon-coupon.png" alt="쿠폰" class="user-icon"/></a>
             <a class="user-link" href="/mypage"><img src="/img/icon-mypage.png" alt="마이페이지" class="user-icon"/></a>
-            <a class="user-link" href="/api/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+            <a class="user-link" href="/cart"><img src="/img/icon-cart.png" alt="장바구니" class="user-icon"/></a>
+
+            <a th:if="${myInfo == null}" class="user-link pill" th:href="@{/login}">로그인</a>
+            <a th:if="${myInfo != null}" class="user-link pill" th:href="@{/logout}">로그아웃</a>
         </div>
     </div>
 </header>


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #165

## 📝작업 내용

> 마이페이지 주문 내역을 구현하고 마이페이지 각 탭 헤더만 임시로 통일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 주문 내역 페이지 추가 — 주문 목록, 상세 항목 및 페이지네이션 제공
  * 주문 취소 기능(클라이언트 사이드) 추가
  * 헤더 통합 검색 기능 추가(여러 마이페이지 템플릿에 반영)

* **스타일**
  * 주문 상태 뱃지(대기중, 완료, 취소) UI 개선
  * 내비게이션 및 로그인/로그아웃 링크 업데이트(조건부 렌더링 반영)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->