### PR TITLE
refactor: 휴면 회원 인증 중복 검사 제거[#237]

### DIFF
--- a/src/main/java/com/example/high_five/controller/auth/AuthRestController.java
+++ b/src/main/java/com/example/high_five/controller/auth/AuthRestController.java
@@ -104,13 +104,6 @@ public class AuthRestController {
     @PostMapping("/dormant/verify")
     public ResponseEntity<String> verifyAndActivate(@RequestBody DormantRequest request) {
         try {
-            EmailVerifyRequest verifyReq = new EmailVerifyRequest(
-                    request.getEmail(),
-                    request.getAuthCode(),
-                    "ACTIVATE"
-            );
-            authService.verifyEmail(verifyReq);
-
             memberService.activateDormant(request);
 
             return ResponseEntity.ok("휴면 상태가 해제되었습니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> #237

## 📝작업 내용

> 휴면 회원 인증 중복 검사 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 휴면 계정 활성화 프로세스가 간소화되었습니다. 이제 이메일 인증 단계를 거치지 않고 직접 계정을 활성화할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->