### PR TITLE
페이코 로그인 시 유저 상태별 에러코드 구현 

### DIFF
--- a/src/main/java/com/example/high_five/controller/auth/AuthController.java
+++ b/src/main/java/com/example/high_five/controller/auth/AuthController.java
@@ -155,6 +155,11 @@ public class AuthController {
 
             return "redirect:/";
 
+        } catch (FeignException e) {
+            FeignError fe = extractFeignError(e);
+            log.warn("소셜 로그인 실패 (Feign): code={}, message={}", fe.code(), fe.message());
+            rttr.addAttribute("errorCode", fe.code());
+            return "redirect:/member/login";
         } catch (Exception e) {
             log.error("소셜 로그인 실패", e);
             rttr.addAttribute("errorCode", "C002");


### PR DESCRIPTION
## #️⃣연관된 이슈

> [#214]

## 📝작업 내용

> 페이코 로그인 시 유저 상태별 에러코드 구현 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인 중 외부 서비스 연동 오류 발생 시 사용자에게 명확한 오류 메시지를 제공하도록 개선했습니다. 더욱 체계적인 오류 처리로 로그인 실패 상황에서 더 나은 피드백을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->