### PR TITLE
페이코 로그인 시 유저 상태별 에러코드 구현

### DIFF
--- a/src/main/java/com/example/high_five/controller/auth/AuthController.java
+++ b/src/main/java/com/example/high_five/controller/auth/AuthController.java
@@ -2,10 +2,9 @@ package com.example.high_five.controller.auth;
 
 import com.example.high_five.dto.member.request.LoginRequest;
 import com.example.high_five.dto.member.response.TokenDto;
+import com.example.high_five.exception.FeignErrorParser;
 import com.example.high_five.exception.LoginErrorMapper;
 import com.example.high_five.service.AuthService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,9 +26,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class AuthController {
 
     private final AuthService authService;
-    private final ObjectMapper objectMapper;
-
-    private record FeignError(String code, String message) {}
+    private final FeignErrorParser feignErrorParser;
 
     @Value("${jwt.expiration_time}")
     private Long accessExpirationTime;
@@ -45,10 +42,7 @@ public class AuthController {
             Model model
     ) {
         if (errorCode != null && !errorCode.isBlank()) {
-            model.addAttribute(
-                    "errorMessage",
-                    LoginErrorMapper.toMessage(errorCode)
-            );
+            model.addAttribute("errorMessage", LoginErrorMapper.toMessage(errorCode));
         }
         return "member/login";
     }
@@ -63,9 +57,7 @@ public class AuthController {
             ResponseEntity<TokenDto> apiResponse = authService.login(loginRequest);
             TokenDto tokens = apiResponse.getBody();
 
-            if (tokens == null) {
-                throw new RuntimeException("토큰 없음");
-            }
+            if (tokens == null) throw new RuntimeException("토큰 없음");
 
             setCookie(response, "access-token", tokens.getAccessToken(), accessExpirationTime);
             setCookie(response, "refresh-token", tokens.getRefreshToken(), refreshExpirationTime);
@@ -73,14 +65,14 @@ public class AuthController {
             return "redirect:/";
 
         } catch (FeignException e) {
-            FeignError fe = extractFeignError(e);
-            log.warn("로그인 실패 (Feign): code={}, message={}", fe.code(), fe.message());
+            FeignErrorParser.FeignError fe =
+                    feignErrorParser.parse(e, "C002", "로그인에 실패했습니다.");
 
+            log.warn("로그인 실패 (Feign): code={}, message={}", fe.code(), fe.message());
             rttr.addAttribute("errorCode", fe.code());
             return "redirect:/member/login";
 
         } catch (Exception e) {
-
             log.error("로그인 시스템 오류", e);
             rttr.addAttribute("errorCode", "C002");
             return "redirect:/member/login";
@@ -90,9 +82,7 @@ public class AuthController {
     @PostMapping("/auth/reissue")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = resolveCookie(request, "refresh-token");
-        if (refreshToken == null) {
-            return ResponseEntity.status(401).build();
-        }
+        if (refreshToken == null) return ResponseEntity.status(401).build();
 
         try {
             ResponseEntity<TokenDto> apiResponse = authService.reissue(refreshToken);
@@ -141,9 +131,7 @@ public class AuthController {
             ResponseEntity<TokenDto> apiResponse = authService.loginSocial(provider, code);
             TokenDto tokens = apiResponse.getBody();
 
-            if (tokens == null) {
-                throw new RuntimeException("소셜 로그인 실패");
-            }
+            if (tokens == null) throw new RuntimeException("소셜 로그인 실패");
 
             setCookie(response, "access-token", tokens.getAccessToken(), accessExpirationTime);
             setCookie(response, "refresh-token", tokens.getRefreshToken(), refreshExpirationTime);
@@ -156,10 +144,13 @@ public class AuthController {
             return "redirect:/";
 
         } catch (FeignException e) {
-            FeignError fe = extractFeignError(e);
+            FeignErrorParser.FeignError fe =
+                    feignErrorParser.parse(e, "C002", "소셜 로그인에 실패했습니다.");
+
             log.warn("소셜 로그인 실패 (Feign): code={}, message={}", fe.code(), fe.message());
             rttr.addAttribute("errorCode", fe.code());
             return "redirect:/member/login";
+
         } catch (Exception e) {
             log.error("소셜 로그인 실패", e);
             rttr.addAttribute("errorCode", "C002");
@@ -186,35 +177,5 @@ public class AuthController {
             if (name.equals(c.getName())) return c.getValue();
         }
         return null;
-    }
-
-    private FeignError extractFeignError(FeignException e) {
-        try {
-            String body = e.contentUTF8();
-
-            if (body == null || body.isBlank()) {
-                body = e.responseBody()
-                        .map(bb -> java.nio.charset.StandardCharsets.UTF_8.decode(bb).toString())
-                        .orElse("");
-            }
-
-            if (body.isBlank()) {
-                if (e.status() == 401) {
-                    return new FeignError("A002", "아이디 또는 비밀번호가 올바르지 않습니다.");
-                }
-                return new FeignError("C002", "로그인에 실패했습니다.");
-            }
-
-            JsonNode node = objectMapper.readTree(body);
-            String code = node.has("code") ? node.get("code").asText() : "C002";
-            String msg  = node.has("message") ? node.get("message").asText() : "로그인에 실패했습니다.";
-            return new FeignError(code, msg);
-
-        } catch (Exception ex) {
-            if (e.status() == 401) {
-                return new FeignError("A002", "아이디 또는 비밀번호가 올바르지 않습니다.");
-            }
-            return new FeignError("C002", "로그인에 실패했습니다.");
-        }
     }
 }

--- a/src/main/java/com/example/high_five/controller/member/MemberController.java
+++ b/src/main/java/com/example/high_five/controller/member/MemberController.java
@@ -3,10 +3,9 @@ package com.example.high_five.controller.member;
 import com.example.high_five.common.annotation.LoginRequired;
 import com.example.high_five.dto.member.request.MemberCreateRequestDto;
 import com.example.high_five.dto.member.request.MemberUpdateRequest;
+import com.example.high_five.exception.FeignErrorParser;
 import com.example.high_five.service.AuthService;
 import com.example.high_five.service.MemberService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,7 +23,8 @@ public class MemberController {
 
     private final MemberService memberService;
     private final AuthService authService;
-    private final ObjectMapper objectMapper;
+    private final FeignErrorParser feignErrorParser;
+
     @GetMapping("/member/signup")
     public String signupForm() {
         return "member/signup";
@@ -36,21 +36,24 @@ public class MemberController {
             authService.signup(requestDto);
             return "redirect:/member/login";
         } catch (Exception e) {
-            log.error("회원가입 실패: {}", e.getMessage());
+            log.error("회원가입 실패: {}", e.getMessage(), e);
             return "redirect:/member/signup?error=true";
         }
     }
 
     @LoginRequired
     @GetMapping("/mypage")
-    public String myPage(Model model) {
+    public String myPage(Model model,
+                         @RequestParam(value = "alertCode", required = false) String alertCode) {
         try {
             var myInfo = memberService.getMyInfo().getBody();
             model.addAttribute("myInfo", myInfo);
         } catch (FeignException e) {
-            log.error("내 정보 조회 실패: {}", e.getMessage());
+            log.error("내 정보 조회 실패: {}", e.getMessage(), e);
             return "redirect:/member/login";
         }
+
+        model.addAttribute("alertCode", alertCode);
         model.addAttribute("currentTab", "info");
         return "mypage/myinfo";
     }
@@ -58,28 +61,45 @@ public class MemberController {
     @LoginRequired
     @PostMapping("/mypage/update")
     public String updateMember(@ModelAttribute MemberUpdateRequest request,
-                               RedirectAttributes redirectAttributes) {
+                               RedirectAttributes rttr) {
         try {
             memberService.updateMember(request);
-            redirectAttributes.addFlashAttribute("alertMessage", "수정되었습니다.");
+
+            rttr.addAttribute("alertCode", "MP200");
+            return "redirect:/mypage";
+
         } catch (FeignException e) {
-            String msg = extractFeignMessage(e); // 아래 함수
-            redirectAttributes.addFlashAttribute("alertMessage", msg);
+            FeignErrorParser.FeignError fe =
+                    feignErrorParser.parse(e, "C002", "수정에 실패했습니다.");
+
+            rttr.addAttribute("alertCode", fe.code());
+            return "redirect:/mypage";
+
+        } catch (Exception e) {
+            rttr.addAttribute("alertCode", "C002");
+            return "redirect:/mypage";
         }
-        return "redirect:/mypage";
     }
 
     @LoginRequired
     @PostMapping("/mypage/withdraw")
-    public String withdrawMember(HttpServletResponse response, RedirectAttributes redirectAttributes) {
+    public String withdrawMember(HttpServletResponse response, RedirectAttributes rttr) {
         try {
             memberService.withdrawMember();
             deleteCookie(response, "access-token");
             deleteCookie(response, "refresh-token");
-            redirectAttributes.addFlashAttribute("message", "탈퇴되었습니다.");
+
+            rttr.addAttribute("alertCode", "MP201"); // 예: 탈퇴 성공 코드
             return "redirect:/";
+
+        } catch (FeignException e) {
+            FeignErrorParser.FeignError fe =
+                    feignErrorParser.parse(e, "C002", "탈퇴에 실패했습니다.");
+            rttr.addAttribute("alertCode", fe.code());
+            return "redirect:/mypage";
+
         } catch (Exception e) {
-            redirectAttributes.addFlashAttribute("errorMessage", "탈퇴 실패");
+            rttr.addAttribute("alertCode", "C002");
             return "redirect:/mypage";
         }
     }
@@ -89,19 +109,5 @@ public class MemberController {
         cookie.setMaxAge(0);
         cookie.setPath("/");
         response.addCookie(cookie);
-    }
-
-    private String extractFeignMessage(FeignException e) {
-        try {
-            String body = e.contentUTF8();
-            if (body == null || body.isBlank()) return "요청 처리 중 오류가 발생했습니다.";
-
-            JsonNode node = objectMapper.readTree(body);
-
-            if (node.has("message")) return node.get("message").asText();
-            return body;
-        } catch (Exception ex) {
-            return "요청 처리 중 오류가 발생했습니다.";
-        }
     }
 }

--- a/src/main/java/com/example/high_five/exception/FeignErrorParser.java
+++ b/src/main/java/com/example/high_five/exception/FeignErrorParser.java
@@ -1,0 +1,51 @@
+package com.example.high_five.exception;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class FeignErrorParser {
+
+    private final ObjectMapper objectMapper;
+
+    public record FeignError(String code, String message) {}
+
+    public FeignError parse(FeignException e, String defaultCode, String defaultMessage) {
+        String body = readBody(e);
+
+        if (body == null || body.isBlank()) {
+            return statusFallback(e, defaultCode, defaultMessage);
+        }
+
+        try {
+            JsonNode node = objectMapper.readTree(body);
+            String code = node.has("code") ? node.get("code").asText() : defaultCode;
+            String msg  = node.has("message") ? node.get("message").asText() : defaultMessage;
+            return new FeignError(code, msg);
+        } catch (Exception ignore) {
+            return statusFallback(e, defaultCode, defaultMessage);
+        }
+    }
+
+    private String readBody(FeignException e) {
+        String body = e.contentUTF8();
+        if (body != null && !body.isBlank()) return body;
+
+        return e.responseBody()
+                .map(bb -> StandardCharsets.UTF_8.decode(bb).toString())
+                .orElse("");
+    }
+
+    private FeignError statusFallback(FeignException e, String defaultCode, String defaultMessage) {
+        if (e.status() == 401) {
+            return new FeignError("A002", "아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+        return new FeignError(defaultCode, defaultMessage);
+    }
+}

--- a/src/main/resources/static/js/myinfo.js
+++ b/src/main/resources/static/js/myinfo.js
@@ -15,8 +15,7 @@ const autoHyphen = (target) => {
     } else {
         target.innerText = val;
     }
-}
-
+};
 
 document.addEventListener("DOMContentLoaded", () => {
     const viewPhone = document.getElementById("view-phone");
@@ -28,14 +27,27 @@ document.addEventListener("DOMContentLoaded", () => {
     handleAlertMessage();
 });
 
+function mapAlertCodeToMessage(code) {
+    const map = {
+        "MP200": "수정되었습니다.",
+        "M011": "이미 존재하는 이메일입니다.",
+        "M012": "이미 존재하는 전화번호입니다.",
+        "M013": "생일은 변경할 수 없습니다.",
+        "C002": "요청 처리 중 오류가 발생했습니다."
+    };
+    return map[code] || "요청 처리 중 오류가 발생했습니다.";
+}
+
 function handleAlertMessage() {
     const serverMsgInput = document.getElementById('server-alert-msg');
     const modelMessage = serverMsgInput ? serverMsgInput.value : null;
 
     const urlParams = new URLSearchParams(window.location.search);
+
+    const alertCode = urlParams.get('alertCode');
     const urlMessage = urlParams.get('errorMessage');
 
-    const finalMessage = modelMessage || urlMessage;
+    const finalMessage = modelMessage || urlMessage || (alertCode ? mapAlertCodeToMessage(alertCode) : null);
 
     if (finalMessage) {
         alert(finalMessage);
@@ -44,7 +56,7 @@ function handleAlertMessage() {
             setTimeout(() => toggleEditMode(true), 100);
         }
 
-        if (urlMessage) {
+        if (urlMessage || alertCode) {
             history.replaceState(null, "", location.pathname);
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> [#214]

## 📝작업 내용

> 페이코 로그인 시 유저 상태별 에러코드 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 로그인 및 소셜 로그인의 오류 처리를 개선하여 더 명확한 오류 메시지 제공
  * 회원 정보 수정 및 탈퇴 기능의 오류 처리 강화
  * 회원 정보 페이지의 알림 메시지 표시 로직 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->