### PR TITLE
fix: 활성화된 쿠폰만 선택 가능하게 수정

### DIFF
--- a/src/main/resources/templates/admin/coupons.html
+++ b/src/main/resources/templates/admin/coupons.html
@@ -157,6 +157,7 @@
                                 <select name="id" required>
                                     <option value="">-- 정책을 선택하세요 --</option>
                                     <option th:each="policy : ${policies}"
+                                            th:if="${policy.status != null and policy.status.name() == 'ACTIVE'}"
                                             th:value="${policy.id}"
                                             th:text="${policy.name}">
                                         정책 이름
@@ -295,6 +296,7 @@
                                 <select name="couponId" required>
                                     <option value="">-- 쿠폰 선택 --</option>
                                     <option th:each="coupon : ${coupons}"
+                                            th:if="${coupon.status == 'ACTIVE'}"
                                             th:value="${coupon.id}"
                                             th:text="${coupon.couponName} + ' (ID: ' + ${coupon.id} + ')'">
                                         쿠폰명


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 활성화된 쿠폰만 선택 가능하게 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 쿠폰 템플릿 생성 섹션에서 활성 상태의 정책만 표시하도록 개선
* 회원 쿠폰 수동 지급 섹션에서 활성 상태의 쿠폰만 표시하도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->